### PR TITLE
Added uncompressed address to address generation

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -27,7 +27,16 @@ impl Couple {
         }
     }
 
-    pub fn starts_with_any(&self, starts_with: &str, case_sensitive: bool) -> bool {
+    pub fn starts_with_any(&self, addresses: &[String], case_sensitive: bool) -> bool {
+        for address in addresses.iter() {
+            if self.starts_with(address, case_sensitive) {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn starts_with(&self, starts_with: &str, case_sensitive: bool) -> bool {
         self.uncompressed.starts_with(starts_with, case_sensitive)
             || self.compressed.starts_with(starts_with, case_sensitive)
     }
@@ -74,14 +83,5 @@ impl Address {
                 .to_lowercase()
                 .starts_with(starts_with)
         }
-    }
-
-    pub fn starts_with_any(&self, addresses: &[String], case_sensitive: bool) -> bool {
-        for address in addresses.iter() {
-            if self.starts_with(address, case_sensitive) {
-                return true;
-            }
-        }
-        false
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -10,6 +10,29 @@ fn get_random_buf() -> [u8; constants::SECRET_KEY_SIZE] {
     buf
 }
 
+pub struct Couple {
+    pub uncompressed: Address,
+    pub compressed: Address,
+}
+
+impl Couple {
+    pub fn new(secp: &Secp256k1<impl Signing>) -> Couple {
+        let random_buf = get_random_buf();
+        let uncompressed = Address::new(secp, &random_buf, false);
+        let compressed = Address::new(secp, &random_buf, true);
+
+        Couple {
+            uncompressed,
+            compressed,
+        }
+    }
+
+    pub fn starts_with_any(&self, starts_with: &str, case_sensitive: bool) -> bool {
+        self.uncompressed.starts_with(starts_with, case_sensitive)
+            || self.compressed.starts_with(starts_with, case_sensitive)
+    }
+}
+
 pub struct Address {
     pub private_key: util::key::PrivateKey,
     pub public_key: util::key::PublicKey,
@@ -17,9 +40,8 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(secp: &Secp256k1<impl Signing>) -> Address {
-        let random_buf = get_random_buf();
-        let secret_key = match SecretKey::from_slice(&random_buf) {
+    pub fn new(secp: &Secp256k1<impl Signing>, data: &[u8], compressed: bool) -> Address {
+        let key = match SecretKey::from_slice(data) {
             Ok(sk) => sk,
             Err(err) => panic!(
                 "Error creating secret key from random bytes {:?}",
@@ -27,17 +49,18 @@ impl Address {
             ),
         };
 
-        let priv_key = util::key::PrivateKey {
-            compressed: true,
+        let private_key = util::key::PrivateKey {
+            compressed,
             network: Network::Bitcoin,
-            key: secret_key,
+            key,
         };
-        let pub_key = util::key::PublicKey::from_private_key(&secp, &priv_key);
-        let address = util::address::Address::p2pkh(&pub_key, Network::Bitcoin);
+
+        let public_key = util::key::PublicKey::from_private_key(&secp, &private_key);
+        let address = util::address::Address::p2pkh(&public_key, Network::Bitcoin);
 
         Address {
-            private_key: priv_key,
-            public_key: pub_key,
+            private_key,
+            public_key,
             address,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,8 +102,8 @@ fn load_file_into_vector(file_name: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use secp256k1::Secp256k1;
     use crate::address::Couple;
+    use secp256k1::Secp256k1;
 
     #[test]
     fn create_bitcoin_public_key() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
 
         rayon::iter::repeat(Couple::new)
             .map(|compute_addr| compute_addr(&secp))
-            .find_any(|couple| couple.starts_with_any(&starts_with, case_sensitive))
+            .find_any(|couple| couple.starts_with(&starts_with, case_sensitive))
             .unwrap()
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod address;
 
-use address::Address;
+use address::Couple;
 use rayon::iter::ParallelIterator;
 use secp256k1::Secp256k1;
 use serde_json::json;
@@ -39,13 +39,13 @@ fn main() {
     let started_at = Instant::now();
     let secp = Secp256k1::new();
     let case_sensitive: bool = !matches.is_present("case_sensitive");
-    let address: Address = if matches.is_present("file_input") {
+    let couple: Couple = if matches.is_present("file_input") {
         let file_name: &str = matches.value_of("file_input").unwrap();
         let addresses = load_file_into_vector(file_name);
 
-        rayon::iter::repeat(Address::new)
+        rayon::iter::repeat(Couple::new)
             .map(|compute_addr| compute_addr(&secp))
-            .find_any(|addr| addr.starts_with_any(&addresses, case_sensitive))
+            .find_any(|couple| couple.starts_with_any(&addresses, case_sensitive))
             .unwrap()
     } else {
         let starts_with: String = if case_sensitive {
@@ -54,18 +54,25 @@ fn main() {
             matches.value_of("startswith").unwrap().to_lowercase()
         };
 
-        rayon::iter::repeat(Address::new)
+        rayon::iter::repeat(Couple::new)
             .map(|compute_addr| compute_addr(&secp))
-            .find_any(|addr| addr.starts_with(&starts_with, case_sensitive))
+            .find_any(|couple| couple.starts_with_any(&starts_with, case_sensitive))
             .unwrap()
     };
 
     spinner.stop();
 
     let result = json!({
-        "private_key": address.private_key.to_string(),
-        "public_key": address.public_key.to_string(),
-        "address": address.address.to_string(),
+        "uncompressed": {
+            "private_key": couple.uncompressed.private_key.to_string(),
+            "public_key": couple.uncompressed.public_key.to_string(),
+            "address": couple.uncompressed.address.to_string()
+        },
+        "compressed": {
+            "private_key": couple.compressed.private_key.to_string(),
+            "public_key": couple.compressed.public_key.to_string(),
+            "address": couple.compressed.address.to_string()
+        },
         "creation_time": started_at.elapsed()
     });
 
@@ -95,15 +102,15 @@ fn load_file_into_vector(file_name: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::address::Address;
     use secp256k1::Secp256k1;
+    use crate::address::Couple;
 
     #[test]
     fn create_bitcoin_public_key() {
         let secp = Secp256k1::new();
-        let address = Address::new(&secp);
+        let couple = Couple::new(&secp);
 
-        let actual = address.public_key.to_string().len();
+        let actual = couple.compressed.public_key.to_string().len();
         let expected = 66;
 
         assert_eq!(actual, expected);
@@ -112,9 +119,9 @@ mod tests {
     #[test]
     fn create_bitcoin_private_key() {
         let secp = Secp256k1::new();
-        let address = Address::new(&secp);
+        let couple = Couple::new(&secp);
 
-        let actual = address.private_key.to_string().len();
+        let actual = couple.compressed.private_key.to_string().len();
         let expected = 52;
 
         assert_eq!(actual, expected);
@@ -123,9 +130,9 @@ mod tests {
     #[test]
     fn create_bitcoin_address() {
         let secp = Secp256k1::new();
-        let address = Address::new(&secp);
+        let couple = Couple::new(&secp);
 
-        let actual = address.address.to_string().len();
+        let actual = couple.compressed.address.to_string().len();
         let expected = 34;
 
         assert_eq!(actual, expected);


### PR DESCRIPTION
I am not going to merge this PR as it currently stands: I branched off of master and it will conflict with the other PR.
(I am doing this to not drag different PR's through each others mud.)

This PR adds uncompressed addresses to the generation process.
I added a `Couple` class that holds the couple of bitcoin addresses; the uncompressed and the compressed variant.
I chose not to name it `Pair` because a private key and public key create a (key)pair.

Any improvements, please let me know.


How to test:
- Try it out with `nakatoshi 12345`. On typical runs it takes my PC about 2 minutes to find something like this. With this PR it takes my machine an average 1 minute.
- See how it now spits out 2 addresses. 1 of those will always be irrelevant to your search parameter.