### PR TITLE
Create publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: nakatoshi
+            asset_name: nakatoshi-linux-amd64
+          - os: windows-latest
+            artifact_name: nakatoshi.exe
+            asset_name: nakatoshi-windows-amd64
+          - os: macos-latest
+            artifact_name: nakatoshi
+            asset_name: nakatoshi-macos-amd64
+
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v1
+      - name: Build
+        run: cargo build --release --locked
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}


### PR DESCRIPTION
No idea how to test this other than "just run it"

The idea (I have at least) is to have every github tag trigger a new release build that creates artifacts that are bundled into the github release.

I'd really like Linux and MacOS to work (those are the platforms I develop on).
I'm OK with Windows failing / being scrapped because building the toolchain on Windows is hell (because of gcc/libc) in my experience.
If Github can build `nakatoshi` for Windows, I'll take it, if not, too bad.